### PR TITLE
Adding the raw link to the file header

### DIFF
--- a/Environment Sensor/Environment Sensor.groovy
+++ b/Environment Sensor/Environment Sensor.groovy
@@ -1,3 +1,9 @@
+/******************************************************************************************************
+*
+*  GitHub import link:  
+*  https://raw.githubusercontent.com/iharyadi/hubitat/master/Environment%20Sensor/Environment%20Sensor.groovy
+*
+*******************************************************************************************************/
 metadata {
     definition (name: "Environment Sensor", namespace: "iharyadi", author: "iharyadi", ocfDeviceType: "oic.r.temperature") {
         capability "Configuration"


### PR DESCRIPTION
The raw link allows users to copy it and paste it into the Hubitat Import without having to go back to github.